### PR TITLE
Fix

### DIFF
--- a/one_led_btn.py
+++ b/one_led_btn.py
@@ -4,8 +4,7 @@ from signal import pause
 led = LED(17)
 button = Button(3)
 
-button.when_pressed = led.on()
-button.when_released = led.off()
+button.when_pressed = led.on
+button.when_released = led.off
 
 pause()
-


### PR DESCRIPTION
Functions shouldn't be called when set to when_pressed, that'll run the function once (immediately) and send the return value (None) into when_pressed. Instead when_pressed should be set to a function reference or lambda. I've removed the parentheses to make it a function reference.

i.e. "run this function when the button is pressed"
